### PR TITLE
Memoizable async validation handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,4 @@
-module.exports = require('./regBin');
+module.exports = {
+  sync: require('./regBin'),
+  async: require('./regBinAsync')
+}

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,7 @@
+// const { expect } = require('chai');
+// const index = require('./index');
+
+// describe('The library\'s index file', () => {
+//   it('contains an object with two methods, sync and async')
+
+// });

--- a/package-lock.json
+++ b/package-lock.json
@@ -249,6 +249,11 @@
         "text-encoding": "0.6.4"
       }
     },
+    "node-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "url": "https://github.com/bellentuck/regbin/issues"
   },
   "homepage": "https://github.com/bellentuck/regbin#readme",
-  "dependencies": {},
+  "dependencies": {
+    "node-fetch": "2.1.2"
+  },
   "devDependencies": {
     "chai": "4.1.2",
     "mocha": "5.1.1",

--- a/regBin.js
+++ b/regBin.js
@@ -57,7 +57,7 @@ module.exports = fields => {
   };
 }
 
-
+/// sooooo, does everything need to be promisified now?
 
 
 

--- a/regBin.js
+++ b/regBin.js
@@ -40,6 +40,11 @@ output would be {
 
 */
 
+
+// regBinSync
+// --> regBin.sync({ ... }) ( or: regBin.sync(defaults({ ... })) )
+
+
 const composeValidations = require('./composeValidations');
 
 module.exports = fields => {

--- a/regBinAsync.js
+++ b/regBinAsync.js
@@ -17,7 +17,7 @@ const asyncValidate1 = (values /*, dispatch */) => {
   .catch(errorMessageObj => console.log(errorMessageObj));
 }
 
-asyncValidate1({username: 'john'})
+//asyncValidate1({username: 'john'})
 
 
 //
@@ -99,18 +99,18 @@ const asyncValidate = (fieldName, url, errorMessage, valuesObj, errorsObj, data 
 }
 module.exports = asyncValidate;
 
-const valuesObj = { country: 'Romania' };
-const fieldName = 'country';
+// const valuesObj = { country: 'Romania' };
+// const fieldName = 'country';
 //const input = new RegExp(`*<td>${valuesObj[fieldName]}</td>*`, 'i');
 
 //lookahead: q(?=u)
 // lookbehind: (?<=u)q
 //const input = new RegExp(`(?<=>)${valuesObj[fieldName]}(?=<)`, 'i');
-const url = 'https://developers.google.com/public-data/docs/canonical/countries_csv';
-const errorMessage = 'must be an actual country';//two-digit country code';
-const errorsObj = {};
-asyncValidate(fieldName, url, errorMessage, valuesObj, errorsObj)
-.then(() => console.log('ERRORS OBJ:  ', errorsObj))
+// const url = 'https://developers.google.com/public-data/docs/canonical/countries_csv';
+// const errorMessage = 'must be an actual country';//two-digit country code';
+// const errorsObj = {};
+// asyncValidate(fieldName, url, errorMessage, valuesObj, errorsObj)
+// .then(() => console.log('ERRORS OBJ:  ', errorsObj))
 
 
 //fictional characters?

--- a/regBinAsync.js
+++ b/regBinAsync.js
@@ -1,0 +1,59 @@
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+const errorMessage = { username: 'That username is taken' };
+
+const asyncValidate = (values /*, dispatch */) => {
+  console.log('REQUEST SENT');
+  return sleep(1000)
+    .then(() => {
+      // simulate server latency
+      if (['john', 'paul', 'george', 'ringo'].includes(values.username)) {
+        throw { username: 'That username is taken' };
+        //Promise.reject(new Error(errorMessage.username));
+      }
+    })
+  .catch(errorMessageObj => console.log(errorMessageObj.username));
+}
+
+asyncValidate({username: 'john'})
+
+
+//
+const fetch = require('node-fetch');
+
+
+// on top of this, could memoize.
+
+// helper method
+const findInHtml = (html, thingToFind) => html.split(thingToFind)[1];
+
+/*
+// countries
+fetch('https://developers.google.com/public-data/docs/canonical/countries_csv')
+.then(res => res.text())
+.then(body => {
+  const countriesTable = body.split('table')[1];
+  if (countriesTable.indexOf('Andorra') !== -1) console.log('found Andorra!');
+  // const countryRows = countriesTable.split('<tr>').slice(2);
+
+
+  // const countryInfo = countryRows.split('<td>');
+  // console.log(countryRows[0]);
+})
+*/
+
+// states
+fetch('https://state.1keydata.com/state-abbreviations.php')
+  .then(res => res.text())
+  .then(body => {
+    const data = findInHtml(body, 'alabama.php');
+    if (data.indexOf('Wyoming') !== -1) console.log('yeehaw!');
+  });
+
+// Plan going forward:
+/*
+1. refactor the above into a single method to fetch, given a url, field, and input to search for.
+2. attempt to implement said refactoring as an async validation method. (same scaffolding, only now it's all async. so separate composition process? same composition process?)
+3. test - allow user to enter async fields as well, which (upon completion) will resolve/settle in the same way as sync validations do.
+
+*/

--- a/regBinAsync.js
+++ b/regBinAsync.js
@@ -1,21 +1,23 @@
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-const errorMessage = { username: 'That username is taken' };
+const errorMessage1 = { username: 'That username is taken' };
 
-const asyncValidate = (values /*, dispatch */) => {
-  console.log('REQUEST SENT');
+const asyncValidate1 = (values /*, dispatch */) => {
+  const beatles = ['john', 'paul', 'george', 'ringo'];
+  //console.log('REQUEST SENT', beatles);
   return sleep(1000)
     .then(() => {
+      //console.log('RESPONSE MADE', beatles.includes(values.username))
       // simulate server latency
-      if (['john', 'paul', 'george', 'ringo'].includes(values.username)) {
-        throw { username: 'That username is taken' };
+      if (beatles.includes(values.username)) {
+        throw beatles; //{ username: 'That username is taken' };
         //Promise.reject(new Error(errorMessage.username));
       }
     })
-  .catch(errorMessageObj => console.log(errorMessageObj.username));
+  .catch(errorMessageObj => console.log(errorMessageObj));
 }
 
-asyncValidate({username: 'john'})
+asyncValidate1({username: 'john'})
 
 
 //
@@ -25,7 +27,7 @@ const fetch = require('node-fetch');
 // on top of this, could memoize.
 
 // helper method
-const findInHtml = (html, thingToFind) => html.split(thingToFind)[1];
+//const findInHtml = (html, thingToFind) => html.split(thingToFind)[1];
 
 /*
 // countries
@@ -40,15 +42,17 @@ fetch('https://developers.google.com/public-data/docs/canonical/countries_csv')
   // const countryInfo = countryRows.split('<td>');
   // console.log(countryRows[0]);
 })
+// same goes for country codes, located at the same url.
 */
 
 // states
-fetch('https://state.1keydata.com/state-abbreviations.php')
-  .then(res => res.text())
-  .then(body => {
-    const data = findInHtml(body, 'alabama.php');
-    if (data.indexOf('Wyoming') !== -1) console.log('yeehaw!');
-  });
+// fetch('https://state.1keydata.com/state-abbreviations.php')
+//   .then(res => res.text())
+//   .then(body => {
+//     const data = findInHtml(body, 'alabama.php');
+//     if (data.indexOf('Wyoming') !== -1) console.log('yeehaw!');
+//   });
+
 
 // Plan going forward:
 /*
@@ -56,4 +60,81 @@ fetch('https://state.1keydata.com/state-abbreviations.php')
 2. attempt to implement said refactoring as an async validation method. (same scaffolding, only now it's all async. so separate composition process? same composition process?)
 3. test - allow user to enter async fields as well, which (upon completion) will resolve/settle in the same way as sync validations do.
 
+ALso... https://www.emojibase.com/
+yes. validate emoji shortcode.
+(a) invalid shortcode
+(b) shortcode does not match any emoji
 */
+// fetch('https://www.emojibase.com/')
+//   .then(res => res.text())
+//   .then(body => {
+//     //const data = findInHtml(body, 'alabama.php');
+//     //if (body.indexOf(':grinning:') !== -1) console.log('real emoji.');
+//     if (/[:grining:]/i.test(body)) console.log('real emojy!');
+//   });
+//   //regex2.test(str1)
+
+
+// nb, will have to pre-format fields.
+// i.e., country codes should be all caps
+
+// input = fieldName
+const asyncValidate = (fieldName, url, errorMessage, valuesObj, errorsObj, data = new Map()) => {
+  //const input = new RegExp(`^${valuesObj[fieldName]}$`, 'i');  // has to be a *full* match tho
+  // then input.test(body)
+  //const input = new RegExp(`(?<=>)${valuesObj[fieldName]}(?=<)`)
+  const input = valuesObj[fieldName][0].toUpperCase() + valuesObj[fieldName].slice(1);
+  if (data.has(input)) return;
+  return fetch(url)
+    .then(res => res.text())
+    .then(body => {
+      //if (body.search(input)) data.set(input, true);
+      if (body.indexOf(input) !== -1) data.set(input, true);
+      else throw errorMessage;
+    })
+    .catch(message => {
+      errorsObj[fieldName] = message;
+    })
+    .then(() => data);
+}
+module.exports = asyncValidate;
+
+const valuesObj = { country: 'Romania' };
+const fieldName = 'country';
+//const input = new RegExp(`*<td>${valuesObj[fieldName]}</td>*`, 'i');
+
+//lookahead: q(?=u)
+// lookbehind: (?<=u)q
+//const input = new RegExp(`(?<=>)${valuesObj[fieldName]}(?=<)`, 'i');
+const url = 'https://developers.google.com/public-data/docs/canonical/countries_csv';
+const errorMessage = 'must be an actual country';//two-digit country code';
+const errorsObj = {};
+asyncValidate(fieldName, url, errorMessage, valuesObj, errorsObj)
+.then(() => console.log('ERRORS OBJ:  ', errorsObj))
+
+
+//fictional characters?
+//https://www.britannica.com/topic/list-of-fictional-characters-2045983
+//meh, just go with what ya got so far.
+
+
+
+
+//const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+//const errorMessage = { username: 'That username is taken' };
+
+// const asyncValidate1 = (values /*, dispatch */) => {
+//   console.log('REQUEST SENT');
+//   return sleep(1000)
+//     .then(() => {
+//       // simulate server latency
+//       if (['john', 'paul', 'george', 'ringo'].includes(values.username)) {
+//         throw { username: 'That username is taken' };
+//         //Promise.reject(new Error(errorMessage.username));
+//       }
+//     })
+//   .catch(errorMessageObj => console.log(errorMessageObj.username));
+// }
+
+// asyncValidate1({username: 'john'})

--- a/regBinAsync.test.js
+++ b/regBinAsync.test.js
@@ -1,0 +1,28 @@
+const { expect } = require('chai');
+const asyncValidate = require('./regBinAsync');
+
+describe('The asyncValidate method', () => {
+  const fieldName = 'country';
+  const url = 'https://developers.google.com/public-data/docs/canonical/countries_csv';
+  const errorMessage = 'must be an actual country';
+  let valuesObj, errorsObj;
+  it('Appends to the errors object in the same format as for synchronous validation, if the result is not properly located in the requested resource', () => {
+    errorsObj = {};
+    valuesObj = { country: 'Romania' };
+    asyncValidate(fieldName, url, errorMessage, valuesObj, errorsObj)
+    .then(() => {
+      expect(errorsObj).to.deep.equal({});
+    });
+  });
+  it('Does not append to the errors object if the result is found within the requested resource', () => {
+    errorsObj = {};
+    valuesObj = { country: 'omania' };
+    asyncValidate(fieldName, url, errorMessage, valuesObj, errorsObj)
+    .then(() => {
+      expect(errorsObj).to.deep.equal({ country: errorMessage });
+    });
+  });
+
+});
+
+//asyncV({ country: [] });


### PR DESCRIPTION
Working for a single proper name. (Will want this not so hard-coded in el future.) Tests pass

New dependency: node-fetch

Need to promisify sync stuff? should? to just promises that can immediately settle? so async could become, as in node, the norm?

